### PR TITLE
Update Fusion 360 add-in installation paths to correct directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,13 @@ AI-powered CAD modeling assistant. Describe what you want in plain English, and 
 ### Windows
 Copy the `CADAgent` folder to:
 ```
-%AppData%\Autodesk\ApplicationPlugins\
+%AppData%\Autodesk\Autodesk Fusion 360\API\AddIns
 ```
 
 ### macOS (Web Install)
 Copy the `CADAgent` folder to:
 ```
-~/Library/Application Support/Autodesk/ApplicationPlugins/
+~/Library/Application Support/Autodesk/Autodesk Fusion 360/API/AddIns/
 ```
 
 ### macOS (App Store)

--- a/mac/README.md
+++ b/mac/README.md
@@ -6,7 +6,7 @@
 
 2. Copy the entire `CADAgent` folder to:
    ```
-   ~/Library/Application Support/Autodesk/ApplicationPlugins/
+   ~/Library/Application Support/Autodesk/Autodesk Fusion 360/API/AddIns/
    ```
 
    **Mac App Store version of Fusion?** Use this path instead:

--- a/win/README.md
+++ b/win/README.md
@@ -6,12 +6,12 @@
 
 2. Copy the entire `CADAgent` folder to:
    ```
-   %AppData%\Autodesk\ApplicationPlugins\
+   %AppData%\Autodesk\Autodesk Fusion 360\API\AddIns
    ```
 
    Full path example:
    ```
-   C:\Users\YourName\AppData\Roaming\Autodesk\ApplicationPlugins\CADAgent\
+   C:\Users\YourName\AppData\Roaming\Autodesk\Autodesk Fusion 360\API\AddIns\CADAgent\
    ```
 
 3. Restart Fusion 360


### PR DESCRIPTION
## Summary
Updated installation path documentation across all README files to reflect the correct Autodesk Fusion 360 add-in directory structure. The previous paths were incorrect and would not allow the CADAgent add-in to be properly recognized by Fusion 360.

## Key Changes
- **Windows**: Updated path from `%AppData%\Autodesk\ApplicationPlugins\` to `%AppData%\Autodesk\Autodesk Fusion 360\API\AddIns`
- **macOS (Web Install)**: Updated path from `~/Library/Application Support/Autodesk/ApplicationPlugins/` to `~/Library/Application Support/Autodesk/Autodesk Fusion 360/API/AddIns/`
- Updated documentation in three files:
  - Main README.md
  - win/README.md (with full path example)
  - mac/README.md

## Details
These changes correct the add-in installation paths to match Autodesk Fusion 360's actual expected directory structure. Users following the old paths would have encountered issues with the add-in not being loaded by Fusion 360. The corrected paths now point to the proper `API/AddIns` subdirectories under the Fusion 360-specific application folders.

https://claude.ai/code/session_01WN1NCuDSdGVJuHpmR9XmPy