### PR TITLE
Fallback Supabase defaults and auth-bypass short-circuit for palette auth flows

### DIFF
--- a/mac/CADAgent/CADAgent.py
+++ b/mac/CADAgent/CADAgent.py
@@ -54,6 +54,9 @@ logger = logging.getLogger(__name__)
 # Message types that can arrive in high volume (streaming) and should not spam logs.
 _QUIET_MESSAGE_TYPES = {"reasoning_chunk", "plan_chunk"}
 
+DEFAULT_SUPABASE_URL = "https://wpgibucctvusoizwhsbz.supabase.co"
+DEFAULT_SUPABASE_PUBLISHABLE_KEY = "sb_publishable_VkJwtJWbZn8DwovnrKXIew_W0mr9ix_"
+
 
 def _fusion_probe(message: str) -> None:
     """Best-effort bridge to Fusion's Text Commands log for field diagnostics."""
@@ -182,8 +185,8 @@ class AgentController:
         )
 
         # Supabase auth client
-        supabase_url = os.environ.get("SUPABASE_URL", "")
-        supabase_key = os.environ.get("SUPABASE_PUBLISHABLE_KEY", "")
+        supabase_url = os.environ.get("SUPABASE_URL", DEFAULT_SUPABASE_URL)
+        supabase_key = os.environ.get("SUPABASE_PUBLISHABLE_KEY", DEFAULT_SUPABASE_PUBLISHABLE_KEY)
         self._auth_client: Optional[SupabaseAuthClient] = None
         self._auth_error_emitted: bool = False  # Throttle repetitive auth_error spam
 
@@ -212,7 +215,7 @@ class AgentController:
             except Exception as e:
                 logger.warning(f"Failed to initialize Supabase auth client: {e}")
         else:
-            logger.warning("Supabase credentials not configured in .env")
+            logger.warning("Supabase credentials not configured; falling back to auth bypass")
             # Mirror backend behavior: when Supabase isn't configured, operate in auth bypass mode.
             self._auth_bypass = True
 

--- a/mac/CADAgent/palette_manager.py
+++ b/mac/CADAgent/palette_manager.py
@@ -913,6 +913,15 @@ class HTMLEventHandler(adsk.core.HTMLEventHandler):
             elif action_name == 'check_and_handle_signup':
                 email = payload.get('email', '').strip()
                 logger.info(f"← Check and handle signup request received (email={email})")
+                if self._controller.is_auth_bypass():
+                    logger.info("[auth] bypass enabled; skipping Supabase signup/login flow")
+                    self._palette_manager.send_message(
+                        'auth_success',
+                        message='Auth bypass enabled (dev)',
+                        user={'email': 'dev-bypass@cadagent.local'}
+                    )
+                    self._palette_manager.send_message('user_profile', profile={'email': 'dev-bypass@cadagent.local'})
+                    return
                 if not email:
                     logger.warning("Email is required for signup/login")
                     self._palette_manager.send_message('auth_error', message='Email is required')
@@ -945,6 +954,14 @@ class HTMLEventHandler(adsk.core.HTMLEventHandler):
             elif action_name == 'send_otp_code':
                 email = payload.get('email', '').strip()
                 logger.info(f"← Send OTP code request received (email={email})")
+                if self._controller.is_auth_bypass():
+                    logger.info("[auth] bypass enabled; ignoring OTP send request")
+                    self._palette_manager.send_message(
+                        'auth_success',
+                        message='Auth bypass enabled (dev)',
+                        user={'email': 'dev-bypass@cadagent.local'}
+                    )
+                    return
                 if not email:
                     logger.warning("Email is required for OTP code")
                     self._palette_manager.send_message('auth_error', message='Email is required')
@@ -966,6 +983,15 @@ class HTMLEventHandler(adsk.core.HTMLEventHandler):
                 email = payload.get('email', '').strip()
                 code = payload.get('code', '').strip()
                 logger.info(f"← Verify OTP code request received (email={email})")
+                if self._controller.is_auth_bypass():
+                    logger.info("[auth] bypass enabled; skipping OTP verification")
+                    self._palette_manager.send_message(
+                        'auth_success',
+                        message='Auth bypass enabled (dev)',
+                        user={'email': 'dev-bypass@cadagent.local'}
+                    )
+                    self._palette_manager.send_message('user_profile', profile={'email': 'dev-bypass@cadagent.local'})
+                    return
                 if not email or not code:
                     logger.warning("Email and code are required for OTP verification")
                     self._palette_manager.send_message('auth_error', message='Email and code are required')
@@ -1007,6 +1033,15 @@ class HTMLEventHandler(adsk.core.HTMLEventHandler):
                 access_token = payload.get('access_token', '').strip()
                 refresh_token = payload.get('refresh_token', '').strip()
                 logger.info("← Auth callback received")
+                if self._controller.is_auth_bypass():
+                    logger.info("[auth] bypass enabled; ignoring auth callback")
+                    self._palette_manager.send_message(
+                        'auth_success',
+                        message='Auth bypass enabled (dev)',
+                        user={'email': 'dev-bypass@cadagent.local'}
+                    )
+                    self._palette_manager.send_message('user_profile', profile={'email': 'dev-bypass@cadagent.local'})
+                    return
                 if not access_token or not refresh_token:
                     logger.warning("Missing tokens in auth callback")
                     self._palette_manager.send_message('auth_error', message='Missing authentication tokens')

--- a/win/CADAgent/CADAgent.py
+++ b/win/CADAgent/CADAgent.py
@@ -54,6 +54,9 @@ logger = logging.getLogger(__name__)
 # Message types that can arrive in high volume (streaming) and should not spam logs.
 _QUIET_MESSAGE_TYPES = {"reasoning_chunk", "plan_chunk"}
 
+DEFAULT_SUPABASE_URL = "https://wpgibucctvusoizwhsbz.supabase.co"
+DEFAULT_SUPABASE_PUBLISHABLE_KEY = "sb_publishable_VkJwtJWbZn8DwovnrKXIew_W0mr9ix_"
+
 
 def _fusion_probe(message: str) -> None:
     """Best-effort bridge to Fusion's Text Commands log for field diagnostics."""
@@ -182,8 +185,8 @@ class AgentController:
         )
 
         # Supabase auth client
-        supabase_url = os.environ.get("SUPABASE_URL", "")
-        supabase_key = os.environ.get("SUPABASE_PUBLISHABLE_KEY", "")
+        supabase_url = os.environ.get("SUPABASE_URL", DEFAULT_SUPABASE_URL)
+        supabase_key = os.environ.get("SUPABASE_PUBLISHABLE_KEY", DEFAULT_SUPABASE_PUBLISHABLE_KEY)
         self._auth_client: Optional[SupabaseAuthClient] = None
         self._auth_error_emitted: bool = False  # Throttle repetitive auth_error spam
 
@@ -212,7 +215,7 @@ class AgentController:
             except Exception as e:
                 logger.warning(f"Failed to initialize Supabase auth client: {e}")
         else:
-            logger.warning("Supabase credentials not configured in .env")
+            logger.warning("Supabase credentials not configured; falling back to auth bypass")
             # Mirror backend behavior: when Supabase isn't configured, operate in auth bypass mode.
             self._auth_bypass = True
 

--- a/win/CADAgent/palette_manager.py
+++ b/win/CADAgent/palette_manager.py
@@ -910,6 +910,15 @@ class HTMLEventHandler(adsk.core.HTMLEventHandler):
             elif action_name == 'check_and_handle_signup':
                 email = payload.get('email', '').strip()
                 logger.info(f"← Check and handle signup request received (email={email})")
+                if self._controller.is_auth_bypass():
+                    logger.info("[auth] bypass enabled; skipping Supabase signup/login flow")
+                    self._palette_manager.send_message(
+                        'auth_success',
+                        message='Auth bypass enabled (dev)',
+                        user={'email': 'dev-bypass@cadagent.local'}
+                    )
+                    self._palette_manager.send_message('user_profile', profile={'email': 'dev-bypass@cadagent.local'})
+                    return
                 if not email:
                     logger.warning("Email is required for signup/login")
                     self._palette_manager.send_message('auth_error', message='Email is required')
@@ -942,6 +951,14 @@ class HTMLEventHandler(adsk.core.HTMLEventHandler):
             elif action_name == 'send_otp_code':
                 email = payload.get('email', '').strip()
                 logger.info(f"← Send OTP code request received (email={email})")
+                if self._controller.is_auth_bypass():
+                    logger.info("[auth] bypass enabled; ignoring OTP send request")
+                    self._palette_manager.send_message(
+                        'auth_success',
+                        message='Auth bypass enabled (dev)',
+                        user={'email': 'dev-bypass@cadagent.local'}
+                    )
+                    return
                 if not email:
                     logger.warning("Email is required for OTP code")
                     self._palette_manager.send_message('auth_error', message='Email is required')
@@ -963,6 +980,15 @@ class HTMLEventHandler(adsk.core.HTMLEventHandler):
                 email = payload.get('email', '').strip()
                 code = payload.get('code', '').strip()
                 logger.info(f"← Verify OTP code request received (email={email})")
+                if self._controller.is_auth_bypass():
+                    logger.info("[auth] bypass enabled; skipping OTP verification")
+                    self._palette_manager.send_message(
+                        'auth_success',
+                        message='Auth bypass enabled (dev)',
+                        user={'email': 'dev-bypass@cadagent.local'}
+                    )
+                    self._palette_manager.send_message('user_profile', profile={'email': 'dev-bypass@cadagent.local'})
+                    return
                 if not email or not code:
                     logger.warning("Email and code are required for OTP verification")
                     self._palette_manager.send_message('auth_error', message='Email and code are required')
@@ -1004,6 +1030,15 @@ class HTMLEventHandler(adsk.core.HTMLEventHandler):
                 access_token = payload.get('access_token', '').strip()
                 refresh_token = payload.get('refresh_token', '').strip()
                 logger.info("← Auth callback received")
+                if self._controller.is_auth_bypass():
+                    logger.info("[auth] bypass enabled; ignoring auth callback")
+                    self._palette_manager.send_message(
+                        'auth_success',
+                        message='Auth bypass enabled (dev)',
+                        user={'email': 'dev-bypass@cadagent.local'}
+                    )
+                    self._palette_manager.send_message('user_profile', profile={'email': 'dev-bypass@cadagent.local'})
+                    return
                 if not access_token or not refresh_token:
                     logger.warning("Missing tokens in auth callback")
                     self._palette_manager.send_message('auth_error', message='Missing authentication tokens')


### PR DESCRIPTION
### Motivation

- Provide a sensible default and developer-friendly behavior when Supabase credentials are not configured so the add-in can operate in development or offline scenarios.
- Prevent UI/auth flows from failing or blocking when the backend Supabase service is unavailable by short-circuiting auth actions in bypass mode.

### Description

- Added `DEFAULT_SUPABASE_URL` and `DEFAULT_SUPABASE_PUBLISHABLE_KEY` constants and use them as fallbacks when reading `SUPABASE_URL` and `SUPABASE_PUBLISHABLE_KEY` environment variables in `CADAgent.py` for both Windows and mac builds.
- When Supabase credentials are missing the log message now indicates falling back to auth bypass and the controller sets `_auth_bypass = True` to mirror backend behavior.
- In `palette_manager.py` for both Windows and mac builds, added early checks for `self._controller.is_auth_bypass()` in the `check_and_handle_signup`, `send_otp_code`, `verify_otp_code`, and `auth_callback` handlers to short-circuit Supabase interaction and immediately dispatch `auth_success` and `user_profile` responses with a `dev-bypass@cadagent.local` user.
- Kept existing background-threaded flows intact when not in bypass mode and preserved existing logging and error reporting behavior.

### Testing

- Ran the project's test suite with `pytest -q` and the tests completed successfully.
- Exercised the UI auth handler paths in a local dev run to verify that actions in bypass mode return `auth_success` and `user_profile` without contacting Supabase.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69adbd631bcc832fa7c1b5d1ebfa7414)