### PR TITLE
Handle inline '#' comments in .env loader and preserve quoted values

### DIFF
--- a/mac/CADAgent/CADAgent.py
+++ b/mac/CADAgent/CADAgent.py
@@ -71,6 +71,22 @@ def _fusion_probe(message: str) -> None:
         pass
 
 # Minimal .env loader (avoids dependency on python-dotenv in Fusion sandbox)
+def _strip_inline_env_comment(value: str) -> str:
+    """Strip inline comments from unquoted env values."""
+    in_single = False
+    in_double = False
+    for i, ch in enumerate(value):
+        if ch == '\"' and not in_single:
+            in_double = not in_double
+        elif ch == "'" and not in_double:
+            in_single = not in_single
+        elif ch == '#' and not in_single and not in_double:
+            # Treat as comment only when preceded by whitespace (KEY=VALUE # comment)
+            if i > 0 and value[i - 1].isspace():
+                return value[:i].rstrip()
+    return value
+
+
 def _load_env_file(path: Path) -> None:
     if not path.exists():
         logger.warning(f"Env file not found: {path}")
@@ -84,7 +100,9 @@ def _load_env_file(path: Path) -> None:
                 continue
             key, value = line.split('=', 1)
             key = key.strip()
-            value = value.strip().strip('"').strip("'")
+            value = value.strip()
+            value = _strip_inline_env_comment(value)
+            value = value.strip('"').strip("'")
             if key and key not in os.environ:
                 os.environ[key] = value
         logger.info(f"Loaded environment from {path}")

--- a/mac/CADAgent/config.py
+++ b/mac/CADAgent/config.py
@@ -9,6 +9,22 @@ core code.
 import os
 from pathlib import Path
 
+def _strip_inline_env_comment(value: str) -> str:
+    """Strip inline comments from unquoted env values."""
+    in_single = False
+    in_double = False
+    for i, ch in enumerate(value):
+        if ch == '\"' and not in_single:
+            in_double = not in_double
+        elif ch == "'" and not in_double:
+            in_single = not in_single
+        elif ch == '#' and not in_single and not in_double:
+            # Treat as comment only when preceded by whitespace (KEY=VALUE # comment)
+            if i > 0 and value[i - 1].isspace():
+                return value[:i].rstrip()
+    return value
+
+
 # Load .env.cadagent file before reading any config values
 def _load_env_file(path: Path) -> None:
     """Load environment variables from .env.cadagent file."""
@@ -23,7 +39,9 @@ def _load_env_file(path: Path) -> None:
                 continue
             key, value = line.split('=', 1)
             key = key.strip()
-            value = value.strip().strip('"').strip("'")
+            value = value.strip()
+            value = _strip_inline_env_comment(value)
+            value = value.strip('"').strip("'")
             if key and key not in os.environ:
                 os.environ[key] = value
     except Exception:

--- a/win/CADAgent/CADAgent.py
+++ b/win/CADAgent/CADAgent.py
@@ -71,6 +71,22 @@ def _fusion_probe(message: str) -> None:
         pass
 
 # Minimal .env loader (avoids dependency on python-dotenv in Fusion sandbox)
+def _strip_inline_env_comment(value: str) -> str:
+    """Strip inline comments from unquoted env values."""
+    in_single = False
+    in_double = False
+    for i, ch in enumerate(value):
+        if ch == '\"' and not in_single:
+            in_double = not in_double
+        elif ch == "'" and not in_double:
+            in_single = not in_single
+        elif ch == '#' and not in_single and not in_double:
+            # Treat as comment only when preceded by whitespace (KEY=VALUE # comment)
+            if i > 0 and value[i - 1].isspace():
+                return value[:i].rstrip()
+    return value
+
+
 def _load_env_file(path: Path) -> None:
     if not path.exists():
         logger.warning(f"Env file not found: {path}")
@@ -84,7 +100,9 @@ def _load_env_file(path: Path) -> None:
                 continue
             key, value = line.split('=', 1)
             key = key.strip()
-            value = value.strip().strip('"').strip("'")
+            value = value.strip()
+            value = _strip_inline_env_comment(value)
+            value = value.strip('"').strip("'")
             if key and key not in os.environ:
                 os.environ[key] = value
         logger.info(f"Loaded environment from {path}")

--- a/win/CADAgent/config.py
+++ b/win/CADAgent/config.py
@@ -9,6 +9,22 @@ core code.
 import os
 from pathlib import Path
 
+def _strip_inline_env_comment(value: str) -> str:
+    """Strip inline comments from unquoted env values."""
+    in_single = False
+    in_double = False
+    for i, ch in enumerate(value):
+        if ch == '\"' and not in_single:
+            in_double = not in_double
+        elif ch == "'" and not in_double:
+            in_single = not in_single
+        elif ch == '#' and not in_single and not in_double:
+            # Treat as comment only when preceded by whitespace (KEY=VALUE # comment)
+            if i > 0 and value[i - 1].isspace():
+                return value[:i].rstrip()
+    return value
+
+
 # Load .env.cadagent file before reading any config values
 def _load_env_file(path: Path) -> None:
     """Load environment variables from .env.cadagent file."""
@@ -23,7 +39,9 @@ def _load_env_file(path: Path) -> None:
                 continue
             key, value = line.split('=', 1)
             key = key.strip()
-            value = value.strip().strip('"').strip("'")
+            value = value.strip()
+            value = _strip_inline_env_comment(value)
+            value = value.strip('"').strip("'")
             if key and key not in os.environ:
                 os.environ[key] = value
     except Exception:


### PR DESCRIPTION
### Motivation
- Fix .env parsing so inline `#` comments are treated as comments only when unquoted and preceded by whitespace, avoiding accidental truncation of legitimate `#` characters inside quoted values.
- Apply the parsing fix consistently across both platform add-ins and the shared config loader to ensure environment loading behaves the same on mac and Windows.

### Description
- Added a helper function ` _strip_inline_env_comment` that walks an env value and removes an inline comment only when the `#` is unquoted and preceded by whitespace.
- Updated the minimal `.env` loader in `mac/CADAgent/CADAgent.py` and `win/CADAgent/CADAgent.py` to call the helper before stripping surrounding quotes. 
- Updated `_load_env_file` in both `mac/CADAgent/config.py` and `win/CADAgent/config.py` to use the helper and preserve quoted `#` characters.
- Preserved existing behavior of not overwriting already-set environment variables and silent failure semantics when the env file cannot be read.

### Testing
- Performed an automated syntax check on the modified modules using `python -m py_compile` which completed successfully and reported no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69adc3c61490832faad4ddf42d25ea5c)