### PR TITLE
Append support contact to add-in error messages

### DIFF
--- a/mac/CADAgent/general_utils.py
+++ b/mac/CADAgent/general_utils.py
@@ -13,6 +13,17 @@ from typing import Optional
 
 import adsk.core
 
+SUPPORT_CONTACT_LINE = "If issue persists, email erik@cadagent.co"
+
+
+def _append_support_contact(message: str) -> str:
+    if not message:
+        return SUPPORT_CONTACT_LINE
+    if SUPPORT_CONTACT_LINE.lower() in message.lower():
+        return message
+    separator = "\n\n" if "\n" in message else " "
+    return f"{message}{separator}{SUPPORT_CONTACT_LINE}"
+
 
 def show_message_box(
     title: str,
@@ -29,7 +40,13 @@ def show_message_box(
         app = adsk.core.Application.get()
         ui: Optional[adsk.core.UserInterface] = app.userInterface if app else None
         if ui:
-            ui.messageBox(message, title, icon)
+            text = message
+            if icon in (
+                adsk.core.MessageBoxIconTypes.WarningIconType,
+                adsk.core.MessageBoxIconTypes.CriticalIconType,
+            ):
+                text = _append_support_contact(message)
+            ui.messageBox(text, title, icon)
     except Exception as exc:  # noqa: BLE001 - best-effort logging only
         logging.getLogger(__name__).debug("Failed to show message box: %s", exc, exc_info=True)
 

--- a/mac/CADAgent/palette_manager.py
+++ b/mac/CADAgent/palette_manager.py
@@ -22,8 +22,20 @@ AUTH_MESSAGE_TYPES = frozenset(['auth_success', 'auth_error', 'user_profile'])
 # Critical messages that should be dispatched as soon as palette exists (no visibility/handshake required)
 # Messages that must reach the palette even if the custom send event isn't available yet.
 CRITICAL_MESSAGE_TYPES = frozenset(['connection_status', 'auth_success', 'auth_error', 'user_profile', 'document_switched'])
+SUPPORT_CONTACT_LINE = "If issue persists, email erik@cadagent.co"
+SUPPORT_CONTACT_MESSAGE_TYPES = frozenset(['error', 'auth_error', 'api_keys_error'])
 
 logger = logging.getLogger(__name__)
+
+
+def _append_support_contact(message: str) -> str:
+    """Append support contact details to user-facing error messages."""
+    if not message:
+        return SUPPORT_CONTACT_LINE
+    if SUPPORT_CONTACT_LINE.lower() in message.lower():
+        return message
+    separator = "\n\n" if "\n" in message else " "
+    return f"{message}{separator}{SUPPORT_CONTACT_LINE}"
 
 
 class PaletteSendEventHandler(adsk.core.CustomEventHandler):
@@ -328,6 +340,10 @@ class PaletteManager:
             message_type: Type of message (e.g., 'log', 'connection_status')
             **kwargs: Additional message data
         """
+        if message_type in SUPPORT_CONTACT_MESSAGE_TYPES and isinstance(kwargs.get("message"), str):
+            kwargs = dict(kwargs)
+            kwargs["message"] = _append_support_contact(kwargs["message"])
+
         logger.info(f"→ send_message called: type={message_type}, doc_id={doc_id}, kwargs={kwargs}")
 
         # Recreate palette if it was destroyed (e.g., workspace change)

--- a/win/CADAgent/general_utils.py
+++ b/win/CADAgent/general_utils.py
@@ -13,6 +13,17 @@ from typing import Optional
 
 import adsk.core
 
+SUPPORT_CONTACT_LINE = "If issue persists, email erik@cadagent.co"
+
+
+def _append_support_contact(message: str) -> str:
+    if not message:
+        return SUPPORT_CONTACT_LINE
+    if SUPPORT_CONTACT_LINE.lower() in message.lower():
+        return message
+    separator = "\n\n" if "\n" in message else " "
+    return f"{message}{separator}{SUPPORT_CONTACT_LINE}"
+
 
 def show_message_box(
     title: str,
@@ -29,7 +40,13 @@ def show_message_box(
         app = adsk.core.Application.get()
         ui: Optional[adsk.core.UserInterface] = app.userInterface if app else None
         if ui:
-            ui.messageBox(message, title, icon)
+            text = message
+            if icon in (
+                adsk.core.MessageBoxIconTypes.WarningIconType,
+                adsk.core.MessageBoxIconTypes.CriticalIconType,
+            ):
+                text = _append_support_contact(message)
+            ui.messageBox(text, title, icon)
     except Exception as exc:  # noqa: BLE001 - best-effort logging only
         logging.getLogger(__name__).debug("Failed to show message box: %s", exc, exc_info=True)
 

--- a/win/CADAgent/palette_manager.py
+++ b/win/CADAgent/palette_manager.py
@@ -22,8 +22,20 @@ AUTH_MESSAGE_TYPES = frozenset(['auth_success', 'auth_error', 'user_profile'])
 # Critical messages that should be dispatched as soon as palette exists (no visibility/handshake required)
 # Messages that must reach the palette even if the custom send event isn't available yet.
 CRITICAL_MESSAGE_TYPES = frozenset(['connection_status', 'auth_success', 'auth_error', 'user_profile', 'document_switched'])
+SUPPORT_CONTACT_LINE = "If issue persists, email erik@cadagent.co"
+SUPPORT_CONTACT_MESSAGE_TYPES = frozenset(['error', 'auth_error', 'api_keys_error'])
 
 logger = logging.getLogger(__name__)
+
+
+def _append_support_contact(message: str) -> str:
+    """Append support contact details to user-facing error messages."""
+    if not message:
+        return SUPPORT_CONTACT_LINE
+    if SUPPORT_CONTACT_LINE.lower() in message.lower():
+        return message
+    separator = "\n\n" if "\n" in message else " "
+    return f"{message}{separator}{SUPPORT_CONTACT_LINE}"
 
 
 class PaletteSendEventHandler(adsk.core.CustomEventHandler):
@@ -325,6 +337,10 @@ class PaletteManager:
             message_type: Type of message (e.g., 'log', 'connection_status')
             **kwargs: Additional message data
         """
+        if message_type in SUPPORT_CONTACT_MESSAGE_TYPES and isinstance(kwargs.get("message"), str):
+            kwargs = dict(kwargs)
+            kwargs["message"] = _append_support_contact(kwargs["message"])
+
         logger.info(f"→ send_message called: type={message_type}, doc_id={doc_id}, kwargs={kwargs}")
 
         # Recreate palette if it was destroyed (e.g., workspace change)


### PR DESCRIPTION
## Summary\n- appends `If issue persists, email erik@cadagent.co` to user-facing add-in errors\n- covers palette error messages (`error`, `auth_error`, `api_keys_error`)\n- also appends the same line to Warning/Critical Fusion message boxes\n\n## Scope\n- mac and win add-in code paths updated in parallel\n\n## Why\n- gives users a clear support path when errors are shown in the add-in UI