### PR TITLE
fix: entity capturing bug fixes (mac & win)

### DIFF
--- a/mac/CADAgent/CADAgent.py
+++ b/mac/CADAgent/CADAgent.py
@@ -2024,7 +2024,7 @@ class AgentController:
         # Extract fresh entity context with a short retry loop to avoid transient empties
         entity_context: Optional[Dict[str, Any]] = None
         for attempt in range(3):
-            entity_context = self._extract_entity_context()
+            entity_context = self._extract_entity_context(design)
             total_entities = 0
             if entity_context:
                 total_entities = (
@@ -2333,7 +2333,10 @@ class AgentController:
             "height": target_height,
         }
 
-    def _extract_entity_context(self) -> Optional[Dict[str, Any]]:
+    def _extract_entity_context(
+        self,
+        design: Optional[adsk.fusion.Design] = None,
+    ) -> Optional[Dict[str, Any]]:
         """
         Extract all bodies, faces, and edges from the active design.
 
@@ -2350,9 +2353,14 @@ class AgentController:
         try:
             context: Dict[str, Any] = {}
 
+            if design is None or not getattr(design, "isValid", True):
+                design = adsk.fusion.Design.cast(self._app.activeProduct)
+            if not design or not getattr(design, "isValid", True):
+                return None
+
             # Extract bodies
             try:
-                bodies, body_units = body_tools.list_bodies(self._app)
+                bodies, body_units = body_tools.list_bodies(self._app, design)
                 context["bodies"] = bodies
                 context["body_units"] = body_units
             except Exception as exc:
@@ -2362,7 +2370,7 @@ class AgentController:
 
             # Extract faces
             try:
-                faces, face_units = face_tools.list_faces(self._app)
+                faces, face_units = face_tools.list_faces(self._app, design)
                 context["faces"] = faces
                 context["face_units"] = face_units
             except Exception as exc:
@@ -2372,7 +2380,7 @@ class AgentController:
 
             # Extract edges
             try:
-                edges, edge_units = edge_tools.list_edges(self._app)
+                edges, edge_units = edge_tools.list_edges(self._app, design)
                 context["edges"] = edges
                 context["edge_units"] = edge_units
             except Exception as exc:

--- a/mac/CADAgent/body_tools.py
+++ b/mac/CADAgent/body_tools.py
@@ -65,7 +65,10 @@ def _collect_vertices(body: adsk.fusion.BRepBody) -> List[Dict[str, Any]]:
     return vertices
 
 
-def list_bodies(app: adsk.core.Application) -> Tuple[List[Dict[str, Any]], Dict[str, str]]:
+def list_bodies(
+    app: adsk.core.Application,
+    design: Optional[adsk.fusion.Design] = None,
+) -> Tuple[List[Dict[str, Any]], Dict[str, str]]:
     """
     Collect metadata for every body in the active design, including basic
     physical properties, bounding box coordinates, and vertices.
@@ -74,7 +77,8 @@ def list_bodies(app: adsk.core.Application) -> Tuple[List[Dict[str, Any]], Dict[
         Tuple where the first value is a list of body dictionaries and the second
         value is a mapping of unit identifiers (`length`, `area`, `volume`, `mass`, `density`).
     """
-    design = _require_design(app)
+    if design is None or not getattr(design, "isValid", True):
+        design = _require_design(app)
     root_component = design.rootComponent
     units_manager = design.unitsManager
 

--- a/mac/CADAgent/edge_tools.py
+++ b/mac/CADAgent/edge_tools.py
@@ -162,7 +162,10 @@ def _vertex_info_mm(vertex: Optional[adsk.fusion.BRepVertex]) -> Optional[Dict[s
         return None
 
 
-def list_edges(app: adsk.core.Application) -> Tuple[List[Dict[str, Any]], str]:
+def list_edges(
+    app: adsk.core.Application,
+    design: Optional[adsk.fusion.Design] = None,
+) -> Tuple[List[Dict[str, Any]], str]:
     """
     Collect metadata for every edge in the active design.
 
@@ -170,7 +173,8 @@ def list_edges(app: adsk.core.Application) -> Tuple[List[Dict[str, Any]], str]:
         Tuple where the first value is a list of edge dictionaries and the second
         value is the length unit identifier (always "mm").
     """
-    design = _require_design(app)
+    if design is None or not getattr(design, "isValid", True):
+        design = _require_design(app)
     root_component = design.rootComponent
     units_manager = design.unitsManager
     # Units in mm (convert from Fusion internal cm)

--- a/mac/CADAgent/face_tools.py
+++ b/mac/CADAgent/face_tools.py
@@ -100,7 +100,10 @@ def _extract_face_frame(face: adsk.fusion.BRepFace) -> Optional[Dict[str, List[f
         return None
 
 
-def list_faces(app: adsk.core.Application) -> Tuple[List[Dict[str, Any]], Dict[str, str]]:
+def list_faces(
+    app: adsk.core.Application,
+    design: Optional[adsk.fusion.Design] = None,
+) -> Tuple[List[Dict[str, Any]], Dict[str, str]]:
     """
     Collect metadata for every face in the active design, including boundary edges.
 
@@ -108,7 +111,8 @@ def list_faces(app: adsk.core.Application) -> Tuple[List[Dict[str, Any]], Dict[s
         Tuple where the first value is a list of face dictionaries and the second
         value is a mapping of unit identifiers (`length`, `area`).
     """
-    design = _require_design(app)
+    if design is None or not getattr(design, "isValid", True):
+        design = _require_design(app)
     root_component = design.rootComponent
     units_manager = design.unitsManager
 

--- a/mac/CADAgent/palette_manager.py
+++ b/mac/CADAgent/palette_manager.py
@@ -8,7 +8,7 @@ for the CADAgent add-in with real-time feedback and activity logging.
 import adsk.core
 import json
 import logging
-import os
+from pathlib import Path
 import threading
 import time
 import webbrowser
@@ -185,22 +185,19 @@ class PaletteManager:
         logger.info("Creating (or recreating) palette instance")
 
         # Acquire HTML path
-        html_file = os.path.join(
-            os.path.dirname(__file__),
-            'resources',
-            'html',
-            'index.html'
-        )
-        if not os.path.exists(html_file):
+        html_file = Path(__file__).resolve().parent / 'resources' / 'html' / 'index.html'
+        if not html_file.exists():
             raise FileNotFoundError(f"HTML file not found: {html_file}")
 
+        html_url = html_file.as_uri()
         logger.info(f"HTML file exists: ✓ ({html_file})")
+        logger.info(f"Using palette HTML URL: {html_url}")
 
         # Create palette
         self._palette = palettes.add(
             self.PALETTE_ID,
             self.PALETTE_NAME,
-            html_file,
+            html_url,
             True,   # showCloseButton
             True,   # isResizable
             False,  # isVisible (keep hidden until workspace ready)

--- a/win/CADAgent/CADAgent.py
+++ b/win/CADAgent/CADAgent.py
@@ -2024,7 +2024,7 @@ class AgentController:
         # Extract fresh entity context with a short retry loop to avoid transient empties
         entity_context: Optional[Dict[str, Any]] = None
         for attempt in range(3):
-            entity_context = self._extract_entity_context()
+            entity_context = self._extract_entity_context(design)
             total_entities = 0
             if entity_context:
                 total_entities = (
@@ -2333,7 +2333,10 @@ class AgentController:
             "height": target_height,
         }
 
-    def _extract_entity_context(self) -> Optional[Dict[str, Any]]:
+    def _extract_entity_context(
+        self,
+        design: Optional[adsk.fusion.Design] = None,
+    ) -> Optional[Dict[str, Any]]:
         """
         Extract all bodies, faces, and edges from the active design.
 
@@ -2350,9 +2353,14 @@ class AgentController:
         try:
             context: Dict[str, Any] = {}
 
+            if design is None or not getattr(design, "isValid", True):
+                design = adsk.fusion.Design.cast(self._app.activeProduct)
+            if not design or not getattr(design, "isValid", True):
+                return None
+
             # Extract bodies
             try:
-                bodies, body_units = body_tools.list_bodies(self._app)
+                bodies, body_units = body_tools.list_bodies(self._app, design)
                 context["bodies"] = bodies
                 context["body_units"] = body_units
             except Exception as exc:
@@ -2362,7 +2370,7 @@ class AgentController:
 
             # Extract faces
             try:
-                faces, face_units = face_tools.list_faces(self._app)
+                faces, face_units = face_tools.list_faces(self._app, design)
                 context["faces"] = faces
                 context["face_units"] = face_units
             except Exception as exc:
@@ -2372,7 +2380,7 @@ class AgentController:
 
             # Extract edges
             try:
-                edges, edge_units = edge_tools.list_edges(self._app)
+                edges, edge_units = edge_tools.list_edges(self._app, design)
                 context["edges"] = edges
                 context["edge_units"] = edge_units
             except Exception as exc:

--- a/win/CADAgent/body_tools.py
+++ b/win/CADAgent/body_tools.py
@@ -65,7 +65,10 @@ def _collect_vertices(body: adsk.fusion.BRepBody) -> List[Dict[str, Any]]:
     return vertices
 
 
-def list_bodies(app: adsk.core.Application) -> Tuple[List[Dict[str, Any]], Dict[str, str]]:
+def list_bodies(
+    app: adsk.core.Application,
+    design: Optional[adsk.fusion.Design] = None,
+) -> Tuple[List[Dict[str, Any]], Dict[str, str]]:
     """
     Collect metadata for every body in the active design, including basic
     physical properties, bounding box coordinates, and vertices.
@@ -74,7 +77,8 @@ def list_bodies(app: adsk.core.Application) -> Tuple[List[Dict[str, Any]], Dict[
         Tuple where the first value is a list of body dictionaries and the second
         value is a mapping of unit identifiers (`length`, `area`, `volume`, `mass`, `density`).
     """
-    design = _require_design(app)
+    if design is None or not getattr(design, "isValid", True):
+        design = _require_design(app)
     root_component = design.rootComponent
     units_manager = design.unitsManager
 

--- a/win/CADAgent/edge_tools.py
+++ b/win/CADAgent/edge_tools.py
@@ -162,7 +162,10 @@ def _vertex_info_mm(vertex: Optional[adsk.fusion.BRepVertex]) -> Optional[Dict[s
         return None
 
 
-def list_edges(app: adsk.core.Application) -> Tuple[List[Dict[str, Any]], str]:
+def list_edges(
+    app: adsk.core.Application,
+    design: Optional[adsk.fusion.Design] = None,
+) -> Tuple[List[Dict[str, Any]], str]:
     """
     Collect metadata for every edge in the active design.
 
@@ -170,7 +173,8 @@ def list_edges(app: adsk.core.Application) -> Tuple[List[Dict[str, Any]], str]:
         Tuple where the first value is a list of edge dictionaries and the second
         value is the length unit identifier (always "mm").
     """
-    design = _require_design(app)
+    if design is None or not getattr(design, "isValid", True):
+        design = _require_design(app)
     root_component = design.rootComponent
     units_manager = design.unitsManager
     # Units in mm (convert from Fusion internal cm)

--- a/win/CADAgent/face_tools.py
+++ b/win/CADAgent/face_tools.py
@@ -100,7 +100,10 @@ def _extract_face_frame(face: adsk.fusion.BRepFace) -> Optional[Dict[str, List[f
         return None
 
 
-def list_faces(app: adsk.core.Application) -> Tuple[List[Dict[str, Any]], Dict[str, str]]:
+def list_faces(
+    app: adsk.core.Application,
+    design: Optional[adsk.fusion.Design] = None,
+) -> Tuple[List[Dict[str, Any]], Dict[str, str]]:
     """
     Collect metadata for every face in the active design, including boundary edges.
 
@@ -108,7 +111,8 @@ def list_faces(app: adsk.core.Application) -> Tuple[List[Dict[str, Any]], Dict[s
         Tuple where the first value is a list of face dictionaries and the second
         value is a mapping of unit identifiers (`length`, `area`).
     """
-    design = _require_design(app)
+    if design is None or not getattr(design, "isValid", True):
+        design = _require_design(app)
     root_component = design.rootComponent
     units_manager = design.unitsManager
 


### PR DESCRIPTION
## Summary

- Syncs latest bug fixes for entity capturing across both `mac` and `win` add-in folders
- Updates `CADAgent.py`, `body_tools.py`, `edge_tools.py`, `face_tools.py` (both platforms)
- Updates `palette_manager.py` (mac only)

## Changes

| File | Platforms |
|------|-----------|
| `CADAgent.py` | mac, win |
| `body_tools.py` | mac, win |
| `edge_tools.py` | mac, win |
| `face_tools.py` | mac, win |
| `palette_manager.py` | mac |

## Test plan

- [ ] Load add-in in Fusion 360 on macOS and verify entity capturing works correctly
- [ ] Load add-in in Fusion 360 on Windows and verify entity capturing works correctly
- [ ] Test body, edge, and face selection/capture scenarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)